### PR TITLE
Avoid undefined on Backend

### DIFF
--- a/ganalytics.php
+++ b/ganalytics.php
@@ -664,8 +664,9 @@ class Ganalytics extends Module
 							$ga_scripts .= 'MBG.addTransaction('.$transaction.');';
 						}
 					}
+				return $js.$this->_getGoogleAnalyticsTag(true).$this->_runJs($ga_scripts,1);	
 			}
-			return $js.$this->_getGoogleAnalyticsTag(true).$this->_runJs($ga_scripts,1);
+			
 		}
 		else return $js;
 	}


### PR DESCRIPTION
If we are not in AdminOrders avoid undefined variable $ga_scripts